### PR TITLE
feat: add `after` part +  remove dependency on `make`

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,14 +5,20 @@ manifest required by rocks maintained under the [OCI-Factory](https://github.com
 More information can be found in in the link below.
 https://github.com/canonical/oci-factory/blob/main/IMAGE_MAINTAINER_AGREEMENT.md#enable-security-monitoring
 
-
 To include the manifest as part of your rock copy the following 
 part into the base of your `rockcraft.yaml` project file.
+
 ```
   deb-security-manifest:
-    plugin: make
+    plugin: nil
+    after: [<all-other-slice-names>]
     source: https://github.com/canonical/rocks-security-manifest
     source-type: git
     source-branch: main
+    override-build: ./install_gen_manifest
     override-prime: gen_manifest
 ```
+
+Note the [after](https://documentation.ubuntu.com/rockcraft/stable/common/craft-parts/reference/part_properties/#after) part
+property which ensures that `deb-security-manifest` is generated after all other parts are build, and therefore
+correctly included in the manifest.

--- a/gen_manifest
+++ b/gen_manifest
@@ -21,7 +21,7 @@ echo "# dpkg-query" >> "$manifest_path"
     for deb in /root/parts/*/stage_packages/*.deb; do 
         # TODO: should we assume that all packages are installed correctly (ii)
         # shellcheck disable=SC2016
-        dpkg-deb -W --showformat 'ii,${Package},${Version},,\n' "$deb "
+        dpkg-deb -W --showformat 'ii,${Package},${Version},,\n' "$deb"
     done
     # include all results from chisel manifest
     zstdcat "$CRAFT_STAGE/var/lib/chisel/manifest.wall" \

--- a/gen_manifest
+++ b/gen_manifest
@@ -1,26 +1,30 @@
 #!/bin/bash
+# spellchecker: ignore admindir showformat zstdcat
 
 set -x
-mkdir -p $CRAFT_PRIME/usr/share/rocks/
+mkdir -p "$CRAFT_PRIME/usr/share/rocks/"
 
 manifest_path="$CRAFT_PRIME/usr/share/rocks/dpkg.query"
 
-echo "# os-release" > $manifest_path
-cat /etc/os-release >> $manifest_path
+echo "# os-release" > "$manifest_path"
+cat /etc/os-release >> "$manifest_path"
 
-echo "# dpkg-query" >> $manifest_path
+echo "# dpkg-query" >> "$manifest_path"
 {
     # include all packages in the system
-    dpkg-query --admindir=$CRAFT_PRIME/var/lib/dpkg/ \
+    dpkg-query \
+        --admindir="$CRAFT_PRIME/var/lib/dpkg/" \
         -f '${binary:Package}=${Version},${source:Package}=${Source:Version}\n' \
         -W
 
     # include all .deb files in stage_packages
     for deb in /root/parts/*/stage_packages/*.deb; do 
         # TODO: should we assume that all packages are installed correctly (ii)
-        dpkg-deb -W --showformat 'ii,${Package},${Version},,\n' $deb 
+        # shellcheck disable=SC2016
+        dpkg-deb -W --showformat 'ii,${Package},${Version},,\n' "$deb "
     done
     # include all results from chisel manifest
-    zstdcat $CRAFT_STAGE/var/lib/chisel/manifest.wall | jq -r 'select(.kind == "package") | "ii," + .name + "," + .version + ",,"'
+    zstdcat "$CRAFT_STAGE/var/lib/chisel/manifest.wall" \
+        | jq -r 'select(.kind == "package") | "ii," + .name + "," + .version + ",,"'
 
-} | sort | uniq | tee -a $manifest_path
+} | sort | uniq | tee -a "$manifest_path"

--- a/install_gen_manifest
+++ b/install_gen_manifest
@@ -1,0 +1,8 @@
+#!/bin/bash
+PREFIX=${PREFIX:-/usr}
+BINDIR=${PREFIX}/bin
+SCRIPT=gen_manifest
+
+apt-get install -y zstd jq
+cp "$SCRIPT" "$BINDIR/$SCRIPT"
+chmod +x "$BINDIR/$SCRIPT"


### PR DESCRIPTION
1) Remove dependency on make for a simple script install
2) add `after` part property to ensure manifest is the last step

i've actually started by doing just `2)`, but this triggered a bug where `make` would attempt to use my part's `apt` as opposed to host `apt` which would fail. `1)` resolved it + made this a bit simpler. i've left the makefile for now, for backwards compatibility.

